### PR TITLE
Fix typo

### DIFF
--- a/Peano.tex
+++ b/Peano.tex
@@ -1155,7 +1155,7 @@ Propositions 1-41 also hold if $a,b,...$ indicate sets. In addition, we have:
 \LAT
 56. \hspace{0.67cm} $s \smallIn \K$ . $k$ $\C$ $s$ : $\C$ :: $k \smallIn s$ . = $\pppNoSpace$ $k$ $-$ $=$ $\abs$ : $x$, $y \smallIn k$ . $\C$\scalebox{0.7}{$x, y$}\thinspace . $x$ = $y$
 \ENG
-56. \hspace{0.67cm} $[A \in \setOfSets$ $\wedge$ $( B \subset A)] \rightarrow \Big[ ( B \in A) = \Big( (B \not= \varnothing) \wedge [((x,y) \in B) \xrightarrow[\forall x,y]{} (x=y)] \Big)\Big]$
+56. \hspace{0.67cm} $[A \in \setOfSets$ $\wedge$ $( B \subset A)] \rightarrow \Big[ ( B \in A) = \Big( (B \not= \varnothing) \wedge [(x,y \in B) \xrightarrow[\forall x,y]{} (x=y)] \Big)\Big]$
 \end{translateTwoCol}
 
 \begin{translateTwoCol}


### PR DESCRIPTION
(x,y)\ \in B --> x,y \in B